### PR TITLE
チュートリアルへの導線を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ OSS GateではOSSへの開発参加を支援するワークショップを開催
 ## 日程
 
 OSS Gateワークショップは奇数月の最終土曜日に開催しています。開催予定の日時は[DoorkeeperのOSS Gateコミュニティーのページ](https://oss-gate.doorkeeper.jp/events/upcoming)で確認できます。[OSS Gateコミュニティーに参加](https://oss-gate.doorkeeper.jp/member/new)すると次回開催日の通知を受け取ることができます。
+
+## チュートリアル
+
+[tutorialディレクトリ](tutorial/)の下には、主にワークショップの進行役が利用するための資料が置かれています。まずは[シナリオ](tutorial/scenario.md)を読んで、関連する資料を参照してください。


### PR DESCRIPTION
進行役になった人が最初にアクセスすべき情報へのリンクがわかりずらかったので追加した。