### PR TITLE
Add a description of "OSS Gate" to work log

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,11 @@
+This is a work log of "OSS Gate".
+
+"OSS Gate" is about an activity to increase OSS developers.
+
+Here's been discussed in Japanese. Thanks.
+
+---
+
 OSS Gate へようこそ。
 
 OSS Gateワークショップでは一人ずつ issue を作り、そこに作業ログを残しながら進めます。
@@ -5,7 +13,7 @@ OSS Gateワークショップでは一人ずつ issue を作り、そこに作�
 
 ## この issue 作成時点でまずやること
 
-- この issue のタイトルを「OSS Gateワークショップ ${YEAR}-${MONTH}-${DAY}: ${アカウント名}: ${OSS名}: 作業ログ」の形式でつけてください
+- この issue のタイトルを「OSS Gate Workshop ${YEAR}-${MONTH}-${DAY}: ${アカウント名}: ${OSS名}: Work log」の形式でつけてください
 - OSS 名が未定の場合はタイトルは後からでも変えられるので、とりあえず未定などでも OK です
 
 ## 作業ログを書くタイミング


### PR DESCRIPTION
ワークショップでのフィードバック先 URL を作業ログへ書き込む際に、フィードバックとして PR / ISSUE を出した先のバックリンクが`『OSS Gateワークショップ 2016-12-24: accout_name: oss_name: 作業ログ』`といった形式の日本語タイトルのリンクとなるため、フィードバック先で日本語が分からない場合にビックリしないだろうかと思ったのがきっかけです。

また、フィードバック先から作業ログを参照された際に、OSS Gate の活動と作業ログについて示した簡単な英文があるといいなと思いテンプレートの先頭に付加しています。

フィードバック先には英語が使われていることが多いと思うため、できるだけびっくりさせないような配慮になるといいなと思った点について叩きの案を PR にしてみました。

変更部分への添削やそのほか気に掛かる点がありましたらフィードバックをお願いします。

Merry Christmas :santa: :christmas_tree: :gift: