### PR TITLE
git branchコマンドを追加。

### DIFF
--- a/tutorial/retrospectives/README.md
+++ b/tutorial/retrospectives/README.md
@@ -59,8 +59,9 @@ cloneした後、「`tutorial/retrospectives/${YEAR}-${MONTH}-${DAY}-${LOCATION}
 
 ```console
 % git add beginner-kou.yaml
-% git commit
-% git push
+% git checkout -b {適当なブランチ名}
+% git commit -m"アンケート提出"
+% git push {適当なブランチ名}
 ```
 
 https://github.com/oss-gate/workshop にアクセスするとpull requestを作成するリンクができているはずなのでそのリンクからpull requestを作ります。


### PR DESCRIPTION
現状：
branchを切ってからgit pushしないと、
fork先のリポジトリにpull request用のボタンがあらわれない。

解決：
git checkout -b コマンドをREADMEに追加致しました。