### PR TITLE
use CircleCI for checking answers of survey

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/ruby:2.5.1-browsers
+    environment:
+      TZ: /usr/share/zoneinfo/Asia/Tokyo
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            ./tutorial/retrospectives/test.sh

--- a/tutorial/retrospectives/aggregate.rb
+++ b/tutorial/retrospectives/aggregate.rb
@@ -12,6 +12,7 @@ require "yaml"
 directory = ARGV.shift
 type = ARGV.shift
 target_question = ARGV.shift
+result = true
 
 questionnaires = {}
 Dir.glob("#{directory}/#{type}-*.yaml").sort.each do |yaml|
@@ -20,7 +21,8 @@ Dir.glob("#{directory}/#{type}-*.yaml").sort.each do |yaml|
     begin
       questionnaires[account] = YAML.load(File.read(yaml, encoding: 'BOM|UTF-8'))
     rescue Psych::SyntaxError
-      puts("#{account}: syntax error: #{$!}")
+      $stderr.puts("#{account}: syntax error: #{$!}")
+      result = false
     end
   end
 end
@@ -46,3 +48,4 @@ key_questionnairy["questions"].each do |question, _|
   end
   puts
 end
+exit(result)

--- a/tutorial/retrospectives/test.sh
+++ b/tutorial/retrospectives/test.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+today=`date +%Y-%m-%d`
+result=0
+cd tutorial/retrospectives
+for workshop in `find . -type d -name "${today}*"`; do
+  for type in beginner supporter developer; do
+    if [ -f ${workshop}/${type}.yaml ]; then
+      ./aggregate.rb ${workshop} ${type} >/dev/null
+		if [ ! $? = '0' ]; then
+			result=1
+		fi
+    fi
+  done
+done
+exit ${result}


### PR DESCRIPTION
アンケート回答の文法チェックにCircleCIを使うテスト。

別途CircleCIのセットアップが必要です。とりあえず @tdtds のアカウントで運用しています。

```
CircleCI
    ↓
tutorial/retrospectives/test.sh
    ↓ 当日のディレクトリ内にある回答yamlごとに:
tutorial/retrospectives/aggregate.rb
```

実験してみてよさそうなら採用しますが、masterに入れないと意味がないのでとりあえずマージします。