### PR TITLE
fix: skip error when  data is only 1

### DIFF
--- a/tutorial/retrospectives/aggregate.rb
+++ b/tutorial/retrospectives/aggregate.rb
@@ -26,6 +26,7 @@ Dir.glob("#{directory}/#{type}-*.yaml").sort.each do |yaml|
     end
   end
 end
+exit(false) unless result
 exit(true) if questionnaires.size == 0
 
 _, key_questionnairy = questionnaires.first


### PR DESCRIPTION
アンケートが1件しかない(たとえば回答者によるプルリク)場合に、YAMLファイルにエラーがあっても正常終了になってCIが機能しなかった。これをmasterにマージすると複数アンケートが存在するようになり、はじめてエラーが顕在化する。
1件でもエラーがあった場合には異常終了するように修正。