### PR TITLE
ビギナー繰り上がりを1週間前に早める提案

### DIFF
--- a/.github/ISSUE_TEMPLATE/workshop_preparation.md
+++ b/.github/ISSUE_TEMPLATE/workshop_preparation.md
@@ -30,5 +30,5 @@ about: ワークショップ開催までのタスク管理
 - [ ] 会場決定（開催の1ヶ月前までにやる）
 - [ ] 進行役決定（開催の1ヶ月前までにやる）
 - [ ] サポーター募集のメッセージ作成（開催の2週間前までにやる）
-- [ ] [ビギナーの繰り上がり](https://oss-gate.github.io/workshop/beginner-preferential-treatment.html)処理（開催の3日前にやる）
+- [ ] [ビギナーの繰り上がり](https://oss-gate.github.io/workshop/beginner-preferential-treatment.html)処理（開催の1週間前にやる）
 - [ ] 会場案内のメッセージ作成（開催の3日前までにやる）


### PR DESCRIPTION
東京ワークショップのビギナー繰り上がり処理ですが、3日前だと急すぎて別の予定が入ってしまっているビギナーが多くなってしまう可能性があります(前回のドタキャン率の高さはこれが原因ではないかとみています)。せめて1週間前にしてはどうかという提案です。本当はもっと前のほうが良いと思いますが(2週間前くらい)、とりあえず。