### PR TITLE
Add an interactive mode to tutorial/retrospective/prepare rb

### DIFF
--- a/tutorial/retrospectives/prepare.rb
+++ b/tutorial/retrospectives/prepare.rb
@@ -26,6 +26,7 @@ def set_arguments_interactively(args)
   args.values.each do |arg|
     default = arg[:default]
     print "#{arg[:label]} [#{default}]: "
+    STDOUT.flush
     value = gets.chomp
     arg[:value] = value.empty? ? default : value
   end

--- a/tutorial/retrospectives/prepare.rb
+++ b/tutorial/retrospectives/prepare.rb
@@ -26,7 +26,7 @@ def set_arguments_interactively(args)
   args.each_value do |arg|
     default = arg[:default]
     print "#{arg[:label]} [#{default}]: "
-    STDOUT.flush
+    $stdout.flush
     value = gets.chomp
     arg[:value] = value.empty? ? default : value
   end

--- a/tutorial/retrospectives/prepare.rb
+++ b/tutorial/retrospectives/prepare.rb
@@ -23,7 +23,7 @@ def date_part(date = Date.today)
 end
 
 def set_arguments_interactively(args)
-  args.values.each do |arg|
+  args.each_value do |arg|
     default = arg[:default]
     print "#{arg[:label]} [#{default}]: "
     STDOUT.flush

--- a/tutorial/retrospectives/prepare.rb
+++ b/tutorial/retrospectives/prepare.rb
@@ -1,19 +1,64 @@
 #!/usr/bin/env ruby
 
-if ARGV.size < 2
+if ARGV.size < 1
   puts("Usage: #{$0} DIRECTORY TEMPLATE_TYPE")
   puts(" e.g.: #{$0} 2017-07-29-tokyo workshop")
   puts("")
-  puts("TEMPLATE_TYPE is used to specify the type of template files")
-  puts("to be copied into DIRECTORY.")
-  puts(" e.g.: ./workshop-beginner.yaml is copied to ./DIRECTORY/beginner.yaml ")
+  puts("Usage2: #{$0} LOCATION")
+  puts(" e.g.: #{$0} tokyo")
+  puts(" # With this usage, you can specify DATE and TEMPLATE_TYPE")
+  puts(" # interactively.")
+  puts("")
+  puts("# TEMPLATE_TYPE is used to specify the type of template files")
+  puts("# to be copied into DIRECTORY.")
+  puts("#  e.g.: ./workshop-beginner.yaml is copied to ./DIRECTORY/beginner.yaml ")
   exit(false)
 end
 
 require "fileutils"
+require "date"
 
-directory = ARGV.shift
-type = ARGV.shift
+def date_part(date = Date.today)
+  date.strftime("%Y-%m-%d")
+end
+
+def set_arguments_interactively(args)
+  args.values.each do |arg|
+    default = arg[:default]
+    print "#{arg[:label]} [#{default}]: "
+    value = gets.chomp
+    arg[:value] = value.empty? ? default : value
+  end
+end
+
+args = {
+  date: {
+    label: "DATE",
+    default: date_part,
+    value: nil
+  },
+#  location: {
+#    label: "LOCATION",
+#    default: nil,
+#    value: nil
+#  },
+  type: {
+    label: "TEMPLATE_TYPE",
+    default: "workshop",
+    value: nil
+  }
+}
+
+if ARGV.size == 1 # when a location is specified.
+  location = ARGV.shift
+  set_arguments_interactively(args)
+  directory = "#{args[:date][:value]}-#{location}"
+  type = args[:type][:value]
+else
+  directory = ARGV.shift
+  type = ARGV.shift
+end
+
 
 if File.directory?(directory)
   puts("Directory already exists: #{directory}")

--- a/tutorial/retrospectives/prepare.rb
+++ b/tutorial/retrospectives/prepare.rb
@@ -1,8 +1,12 @@
 #!/usr/bin/env ruby
 
 if ARGV.size < 2
-  puts("Usage: #{$0} DIRECTORY TYPE")
+  puts("Usage: #{$0} DIRECTORY TEMPLATE_TYPE")
   puts(" e.g.: #{$0} 2017-07-29-tokyo workshop")
+  puts("")
+  puts("TEMPLATE_TYPE is used to specify the type of template files")
+  puts("to be copied into DIRECTORY.")
+  puts(" e.g.: ./workshop-beginner.yaml is copied to ./DIRECTORY/beginner.yaml ")
   exit(false)
 end
 

--- a/tutorial/retrospectives/prepare.rb
+++ b/tutorial/retrospectives/prepare.rb
@@ -18,13 +18,6 @@ end
 require "fileutils"
 require "date"
 
-shell_path = ENV["SHELL"]
-
-if shell_path && /Git\\usr\\bin\\bash\.exe$/.match(shell_path)
-  # settings for Git Bash that block calls of gets()
-  STDOUT.sync = true
-end
-
 def date_part(date = Date.today)
   date.strftime("%Y-%m-%d")
 end

--- a/tutorial/retrospectives/prepare.rb
+++ b/tutorial/retrospectives/prepare.rb
@@ -18,6 +18,13 @@ end
 require "fileutils"
 require "date"
 
+shell_path = ENV["SHELL"]
+
+if shell_path && /Git\\usr\\bin\\bash\.exe$/.match(shell_path)
+  # settings for Git Bash that block calls of gets()
+  STDOUT.sync = true
+end
+
 def date_part(date = Date.today)
   date.strftime("%Y-%m-%d")
 end

--- a/tutorial/retrospectives/prepare.rb
+++ b/tutorial/retrospectives/prepare.rb
@@ -18,6 +18,6 @@ end
 
 FileUtils.mkdir_p(directory)
 Dir.glob("#{type}-*.yaml").each do |yaml|
-  yaml_no_type = yaml.sub(/\A#{Regexp.escape(type)}-/, "")
-  FileUtils.cp(yaml, "#{directory}/#{yaml_no_type}")
+  yaml_without_type_prefix = yaml.sub(/\A#{Regexp.escape(type)}-/, "")
+  FileUtils.cp(yaml, "#{directory}/#{yaml_without_type_prefix}")
 end


### PR DESCRIPTION
昨日、2019-10-26の東京ワークショップにサポーターで参加させていただいた@nico-hn です。

昨日を含め計3回参加させていただきましたが、毎回、振り返り時のアンケート準備が煩雑そうに見えます。そのため、[prepare.rb](https://github.com/oss-gate/workshop/blob/master/tutorial/retrospectives/prepare.rb)に手を加え、若干手抜きが出来る(手入力すべき情報が減る）ようにしてみました。

引数が1つだけの時に必要な情報をデフォルト値とともに対話的に聞いてきますが、引数2つで呼び出した時の動作はこれまでと変わりません。

## 現状のスクリプトの呼び出し方法

例l: 2019/10/26 東京開催のワークショップの場合

```
＄ ruby prepare.rb 2019-10-26-tokyo workshop
```
### 問題点（と思われるもの)

* 引数の書式を覚えるのが面倒そう
* [tutorial/retrospectives](https://github.com/oss-gate/workshop/tree/master/tutorial/retrospectives)内を見る限りworkshop用のyamlテンプレートしか用意されていないため、第2引数は決め打ちでも良さそう

## 追加したスクリプトの呼び出し方法

引数として開催地（引数1つ）のみを渡すと、残りの必要な情報である

* 開催日 （デフォルト値としてコマンドの起動日を設定)
* テンプレートの種類 (デフォルト値としてworkshopを設定)

を対話的に聞いてきます。

デフォルト値で良ければそのままエンターキーを押下、値を変えたければ適宜入力してからエンターキーを押下します。


```
＄ ruby prepare.rb tokyo
DATE [2019-10-26]: 
TEMPLATE_TYPE [workshop]: 
```

### 改善点

* 日付の書き方やハイフンの位置等、引数の値の書式を覚えないで済む
* デフォルト値が使えない場合も書式は真似るだけで良い
* (開催日当日に限ってですが)開催地以外はお任せで設定される

## 動作検証済みの環境

* Ubuntu 19.10
  *  Linux 5.3.0-19-generic #20-Ubuntu SMP Fri Oct 18 09:04:39 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux
  * ruby 2.5.5p157 (2019-03-15 revision 67260) [x86_64-linux-gnu]
* Windows 10のコマンドプロンプト(cmd.exe)
  * Windows 10 Home 1903
  * ruby 2.6.5p114 (2019-10-01 revision 67812) [x64-migw32]

