### PR TITLE
PR時Doorkeeper/Connpassのイベント取得をおこなわないように

### DIFF
--- a/.github/workflows/clean-issue-with-pr.yaml
+++ b/.github/workflows/clean-issue-with-pr.yaml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - uses: oss-gate/issue-cleaner@v3
         with:
-          DOORKEEPER_GROUP: oss-gate
-          CONNPASS_KEYWORD: oss gate
           author: ${{ github.event.sender.login }}
         env:
           DOORKEEPER_TOKEN: ${{ secrets.DOORKEEPER_TOKEN }}


### PR DESCRIPTION
#1532 への暫定的な対応です

この変更によって外部のAPIを叩いている処理を動かさなくなるのでissueに上がっている現象は回避できると推測しています