### PR TITLE
準備issueの各タスクの日付を計算するスクリプトを作成しました

### DIFF
--- a/.github/ISSUE_TEMPLATE/workshop_preparation.md
+++ b/.github/ISSUE_TEMPLATE/workshop_preparation.md
@@ -12,6 +12,10 @@ about: ワークショップ開催までのタスク管理
 ## やること
 
 - [ ] Doorkeeperのイベントページ作成（要管理権限）
+- [ ] 以下の各日付`YYYY-MM-DD`をセットする
+  - `prepare/get_preparation_issue_converted_dates.rb` を実行する
+  - オープン状態の各ワークショップ準備issueについて、日付部分を計算して置換したテキストが得られる
+  - 本issueのテキストをコピーして、この内容を差し替える
 - タイムライン、メッセージ送信予定（要管理権限）
   - 開催1ヵ月前（YYYY-MM-DD）
     - [ ] イベント未登録者向け：[サポーター募集文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation.md)

--- a/.github/ISSUE_TEMPLATE/workshop_preparation.md
+++ b/.github/ISSUE_TEMPLATE/workshop_preparation.md
@@ -15,7 +15,7 @@ about: ワークショップ開催までのタスク管理
 - [ ] 以下の各日付`YYYY-MM-DD`をセットする
   - `prepare/get_preparation_issue_converted_dates.rb` を実行する
   - オープン状態の各ワークショップ準備issueについて、日付部分を計算して置換したテキストが得られる
-  - 本issueのテキストをコピーして、この内容を差し替える
+  - 上コマンドで得られたテキストから本issueの部分をコピーして、この内容を差し替える
 - タイムライン、メッセージ送信予定（要管理権限）
   - 開催1ヵ月前（YYYY-MM-DD）
     - [ ] イベント未登録者向け：[サポーター募集文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation.md)

--- a/prepare/get_preparation_issue_converted_dates.rb
+++ b/prepare/get_preparation_issue_converted_dates.rb
@@ -10,14 +10,6 @@ if ARGV.size > 0
   exit(false)
 end
 
-$keywords = [
-  "開催1ヵ月前",
-  "開催2週間前",
-  "開催1週間前",
-  "開催3日前",
-  "開催1日前",
-]
-
 def calc_date(date, keyword)
   case keyword
   when "開催1ヵ月前"

--- a/prepare/get_preparation_issue_converted_dates.rb
+++ b/prepare/get_preparation_issue_converted_dates.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+
+require "uri"
+require "net/http"
+require "json"
+require "date"
+
+if ARGV.size > 0
+  puts("Usage: #{$0}")
+  exit(false)
+end
+
+$keywords = [
+  "開催1ヵ月前",
+  "開催2週間前",
+  "開催1週間前",
+  "開催3日前",
+  "開催1日前",
+]
+
+def calc_date(date, keyword)
+  case keyword
+    when "開催1ヵ月前"
+      return date << 1
+    when "開催2週間前"
+      return date - 14
+    when "開催1週間前"
+      return date - 7
+    when "開催3日前"
+      return date - 3
+    when "開催1日前"
+      return date - 1
+  else
+    raise "Invalid keyword"
+  end
+end
+
+def get_preparation_issues
+  uri = URI("https://api.github.com/repos/oss-gate/workshop/issues")
+  res = Net::HTTP.get_response(uri)
+  return [] unless res.is_a?(Net::HTTPSuccess)
+
+  issues = JSON.parse(res.body)
+
+  issues.select { |issue| issue["title"].start_with?("OSS Gateオンラインワークショップ") }
+end
+
+def convert_body(body, date)
+  converted = ""
+
+  body.each_line do |line|
+    result = line
+    selecteds = $keywords.select { |keyword| line.strip.start_with?("- #{keyword}") }
+    raise "Unexpected line!" if selecteds.length > 1
+    if selecteds.length == 1
+      keyword = selecteds[0]
+      result = "#{line.split(keyword)[0]}#{keyword}(#{calc_date(date, keyword)})\n"
+    end
+    converted << result
+  end
+
+  converted
+end
+
+get_preparation_issues.each do |issue|
+  date = Date.parse(issue["title"].delete_prefix("OSS Gateオンラインワークショップ"))
+  body_converted_dates = convert_body(issue["body"], date)
+
+  puts issue["title"]
+  puts
+  puts body_converted_dates
+  puts
+  puts "-" * 20
+  puts
+end

--- a/prepare/get_preparation_issue_converted_dates.rb
+++ b/prepare/get_preparation_issue_converted_dates.rb
@@ -20,16 +20,16 @@ $keywords = [
 
 def calc_date(date, keyword)
   case keyword
-    when "開催1ヵ月前"
-      return date << 1
-    when "開催2週間前"
-      return date - 14
-    when "開催1週間前"
-      return date - 7
-    when "開催3日前"
-      return date - 3
-    when "開催1日前"
-      return date - 1
+  when "開催1ヵ月前"
+    date << 1
+  when "開催2週間前"
+    date - 14
+  when "開催1週間前"
+    date - 7
+  when "開催3日前"
+    date - 3
+  when "開催1日前"
+    date - 1
   else
     raise "Invalid keyword"
   end

--- a/prepare/get_preparation_issue_converted_dates.rb
+++ b/prepare/get_preparation_issue_converted_dates.rb
@@ -46,20 +46,10 @@ def get_preparation_issues
 end
 
 def convert_body(body, date)
-  converted = ""
-
-  body.each_line do |line|
-    result = line
-    selecteds = $keywords.select { |keyword| line.strip.start_with?("- #{keyword}") }
-    raise "Unexpected line!" if selecteds.length > 1
-    if selecteds.length == 1
-      keyword = selecteds[0]
-      result = "#{line.split(keyword)[0]}#{keyword}(#{calc_date(date, keyword)})\n"
-    end
-    converted << result
+  body.gsub(/(開催.+前)（YYYY-MM-DD）/) do
+    before = Regexp.last_match[1]
+    "#{before}（#{calc_date(date, before)}）"
   end
-
-  converted
 end
 
 get_preparation_issues.each do |issue|


### PR DESCRIPTION
実行すると、オープン状態の全てのワークショップ準備issueを取得します。
そのタイトルから開催日付を取得し、それを元に自動で各タスクの日付を計算して置換します。
自動でissueのbody更新までさせられなかったので、とりあえず置換したテキストを標準出力します。
手動で、その内容でissueのbodyを差し替える想定です。

実行結果例

```console
% ./get_preparation_issue_converted_dates.rb
OSS Gateオンラインワークショップ2023-04-29

## 開催内容

- [イベントページ](https://oss-gate.doorkeeper.jp/events/145991)
- 時間: 2023-04-29T10:30/17:00
- 進行役: @

## やること

- [x] Doorkeeperのイベントページ作成（要管理権限）
- タイムライン、メッセージ送信予定（要管理権限）
  - 開催1ヵ月前(2023-03-29)
    - [ ] イベント未登録者向け：[サポーター募集文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation.md)
    - [ ] Gitter向け: [サポーター募集文面](https://github.com/oss-gate/workshop/raw/master/template/event_notice_for_gitter.md)
  - 開催2週間前(2023-04-15)
    - [ ] 参加者、キャンセル待ち向け：[不参加の場合のキャンセルを呼びかける文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_reminder_before_2_weeks.md)
    - [ ] イベント未登録者向け：[イベント告知、サポーター募集文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation_before_2_weeks.md)
    - [ ] (もし前半枠のサポーターが足りなければ) イベント未登録者向け：[前半枠のみサポーター募集の場合の文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation_only_first_half.md)
    - [ ] (もし後半枠のサポーターが足りなければ) イベント未登録者向け：[後半枠のみサポーター募集の場合の文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation_only_second_half.md)
  - 開催1週間前(2023-04-22)
    - [ ] 進行役決定
    - [ ] [ビギナーの繰り上がり](https://oss-gate.github.io/workshop/beginner-preferential-treatment.html)処理
    - [ ] 参加者、キャンセル待ち向け：[当日の参加方法案内および不参加の場合のキャンセルを呼びかける文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_reminder_before_1_week.md)
  - 開催3日前(2023-04-26)
    - [ ] (もしサポーターが集まらず開催できない場合) 参加者、キャンセル待ち向け：[サポーター不足による中止を伝える文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_canceled.md)
  - 開催1日前(2023-04-28)
    - [ ] 参加者向け：[Discord招待URLの通知用文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_discord_url.md)
    - [ ] (もしサポーターが集まらず開催できない場合) 参加者、キャンセル待ち向け：[サポーター不足による中止を伝える文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_canceled.md)
    - [ ] `tutorial/retrospectives/prepare.rb` を実行してアンケートのテンプレートを追加する（ #1337 ）（要コミット権）
- [ ] 4回分先までのDoorkeeperイベントページの作成（要管理権限）
  1. [イベントリスト](https://manage.doorkeeper.jp/groups/oss-gate/events)を開く。
  2. 「1月と4月と7月と10月は最終土曜日に10:30から17:00で開催」「3月と6月と9月と12月は第2土曜日に13:00から19:00で開催」のルールに従い、同じ開催時刻の未開催イベントまたは過去イベントから「コピーして新規イベント作成」を実行する。
  3. 2のルールに従って開催日を変更する。
  4. 開催日をイベントタイトルに反映する。
  5. ビギナー人数を0に変更する。
  6. イベントを作成する。
  7. イベントに対応するワークショップ準備用issueを作成する。

--------------------

OSS Gateオンラインワークショップ2023-03-11

## 開催内容

- [イベントページ](https://oss-gate.doorkeeper.jp/events/145990)
- 時間: 2023-03-11T13:00/19:00
- 進行役: @

## やること

- [x] Doorkeeperのイベントページ作成（要管理権限）
- タイムライン、メッセージ送信予定（要管理権限）
  - 開催1ヵ月前(2023-02-11)
    - [ ] イベント未登録者向け：[サポーター募集文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation.md)
    - [ ] Gitter向け: [サポーター募集文面](https://github.com/oss-gate/workshop/raw/master/template/event_notice_for_gitter.md)
  - 開催2週間前(2023-02-25)
    - [ ] 参加者、キャンセル待ち向け：[不参加の場合のキャンセルを呼びかける文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_reminder_before_2_weeks.md)
    - [ ] イベント未登録者向け：[イベント告知、サポーター募集文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation_before_2_weeks.md)
    - [ ] (もし前半枠のサポーターが足りなければ) イベント未登録者向け：[前半枠のみサポーター募集の場合の文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation_only_first_half.md)
    - [ ] (もし後半枠のサポーターが足りなければ) イベント未登録者向け：[後半枠のみサポーター募集の場合の文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation_only_second_half.md)
  - 開催1週間前(2023-03-04)
    - [ ] 進行役決定
    - [ ] [ビギナーの繰り上がり](https://oss-gate.github.io/workshop/beginner-preferential-treatment.html)処理
    - [ ] 参加者、キャンセル待ち向け：[当日の参加方法案内および不参加の場合のキャンセルを呼びかける文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_reminder_before_1_week.md)
  - 開催3日前(2023-03-08)
    - [ ] (もしサポーターが集まらず開催できない場合) 参加者、キャンセル待ち向け：[サポーター不足による中止を伝える文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_canceled.md)
  - 開催1日前(2023-03-10)
    - [ ] 参加者向け：[Discord招待URLの通知用文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_discord_url.md)
    - [ ] (もしサポーターが集まらず開催できない場合) 参加者、キャンセル待ち向け：[サポーター不足による中止を伝える文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_canceled.md)
    - [ ] `tutorial/retrospectives/prepare.rb` を実行してアンケートのテンプレートを追加する（ #1337 ）（要コミット権）
- [ ] 4回分先までのDoorkeeperイベントページの作成（要管理権限）
  1. [イベントリスト](https://manage.doorkeeper.jp/groups/oss-gate/events)を開く。
  2. 「1月と4月と7月と10月は最終土曜日に10:30から17:00で開催」「3月と6月と9月と12月は第2土曜日に13:00から19:00で開催」のルールに従い、同じ開催時刻の未開催イベントまたは過去イベントから「コピーして新規イベント作成」を実行する。
  3. 2のルールに従って開催日を変更する。
  4. 開催日をイベントタイトルに反映する。
  5. ビギナー人数を0に変更する。
  6. イベントを作成する。
  7. イベントに対応するワークショップ準備用issueを作成する。

--------------------

OSS Gateオンラインワークショップ2023-01-28

## 開催内容

- [イベントページ](https://oss-gate.doorkeeper.jp/events/141302)
- 時間: 2023-01-28T10:30/17:00
- 進行役: @

## やること

- [x] Doorkeeperのイベントページ作成（要管理権限）
- タイムライン、メッセージ送信予定（要管理権限）
  - 開催1ヵ月前(2022-12-28)
    - [ ] イベント未登録者向け：[サポーター募集文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation.md)
    - [ ] Gitter向け: [サポーター募集文面](https://github.com/oss-gate/workshop/raw/master/template/event_notice_for_gitter.md)
  - 開催2週間前(2023-01-14)
    - [ ] 参加者、キャンセル待ち向け：[不参加の場合のキャンセルを呼びかける文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_reminder_before_2_weeks.md)
    - [ ] イベント未登録者向け：[イベント告知、サポーター募集文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation_before_2_weeks.md)
    - [ ] (もし前半枠のサポーターが足りなければ) イベント未登録者向け：[前半枠のみサポーター募集の場合の文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation_only_first_half.md)
    - [ ] (もし後半枠のサポーターが足りなければ) イベント未登録者向け：[後半枠のみサポーター募集の場合の文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation_only_second_half.md)
  - 開催1週間前(2023-01-21)
    - [ ] 進行役決定
    - [ ] [ビギナーの繰り上がり](https://oss-gate.github.io/workshop/beginner-preferential-treatment.html)処理
    - [ ] 参加者、キャンセル待ち向け：[当日の参加方法案内および不参加の場合のキャンセルを呼びかける文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_reminder_before_1_week.md)
  - 開催3日前(2023-01-25)
    - [ ] (もしサポーターが集まらず開催できない場合) 参加者、キャンセル待ち向け：[サポーター不足による中止を伝える文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_canceled.md)
  - 開催1日前(2023-01-27)
    - [ ] 参加者向け：[Discord招待URLの通知用文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_discord_url.md)
    - [ ] (もしサポーターが集まらず開催できない場合) 参加者、キャンセル待ち向け：[サポーター不足による中止を伝える文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_canceled.md)
    - [ ] `tutorial/retrospectives/prepare.rb` を実行してアンケートのテンプレートを追加する（ #1337 ）（要コミット権）
- [ ] 4回分先までのDoorkeeperイベントページの作成（要管理権限）
  1. [イベントリスト](https://manage.doorkeeper.jp/groups/oss-gate/events)を開く。
  2. 「1月と4月と7月と10月は最終土曜日に10:30から17:00で開催」「3月と6月と9月と12月は第2土曜日に13:00から19:00で開催」のルールに従い、同じ開催時刻の未開催イベントまたは過去イベントから「コピーして新規イベント作成」を実行する。
  3. 2のルールに従って開催日を変更する。
  4. 開催日をイベントタイトルに反映する。
  5. ビギナー人数を0に変更する。
  6. イベントを作成する。
  7. イベントに対応するワークショップ準備用issueを作成する。

--------------------

OSS Gateオンラインワークショップ2022-12-10

## 開催内容

- [イベントページ](https://oss-gate.doorkeeper.jp/events/141301)
- 時間: 2022-12-10T13:00/19:00
- 進行役: @

## やること

- [x] Doorkeeperのイベントページ作成（要管理権限）
- タイムライン、メッセージ送信予定（要管理権限）
  - 開催1ヵ月前(2022-11-10)
    - [ ] イベント未登録者向け：[サポーター募集文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation.md)
    - [ ] Gitter向け: [サポーター募集文面](https://github.com/oss-gate/workshop/raw/master/template/event_notice_for_gitter.md)
  - 開催2週間前(2022-11-26)
    - [ ] 参加者、キャンセル待ち向け：[不参加の場合のキャンセルを呼びかける文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_reminder_before_2_weeks.md)
    - [ ] イベント未登録者向け：[イベント告知、サポーター募集文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation_before_2_weeks.md)
    - [ ] (もし前半枠のサポーターが足りなければ) イベント未登録者向け：[前半枠のみサポーター募集の場合の文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation_only_first_half.md)
    - [ ] (もし後半枠のサポーターが足りなければ) イベント未登録者向け：[後半枠のみサポーター募集の場合の文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_supporter_invitation_only_second_half.md)
  - 開催1週間前(2022-12-03)
    - [ ] 進行役決定
    - [ ] [ビギナーの繰り上がり](https://oss-gate.github.io/workshop/beginner-preferential-treatment.html)処理
    - [ ] 参加者、キャンセル待ち向け：[当日の参加方法案内および不参加の場合のキャンセルを呼びかける文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_reminder_before_1_week.md)
  - 開催3日前(2022-12-07)
    - [ ] (もしサポーターが集まらず開催できない場合) 参加者、キャンセル待ち向け：[サポーター不足による中止を伝える文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_canceled.md)
  - 開催1日前(2022-12-09)
    - [ ] 参加者向け：[Discord招待URLの通知用文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_discord_url.md)
    - [ ] (もしサポーターが集まらず開催できない場合) 参加者、キャンセル待ち向け：[サポーター不足による中止を伝える文面](https://github.com/oss-gate/workshop/raw/master/template/workshop_canceled.md)
    - [ ] `tutorial/retrospectives/prepare.rb` を実行してアンケートのテンプレートを追加する（ #1337 ）（要コミット権）
- [ ] 4回分先までのDoorkeeperイベントページの作成（要管理権限）
  1. [イベントリスト](https://manage.doorkeeper.jp/groups/oss-gate/events)を開く。
  2. 「1月と4月と7月と10月は最終土曜日に10:30から17:00で開催」「3月と6月と9月と12月は第2土曜日に13:00から19:00で開催」のルールに従い、同じ開催時刻の未開催イベントまたは過去イベントから「コピーして新規イベント作成」を実行する。
  3. 2のルールに従って開催日を変更する。
  4. 開催日をイベントタイトルに反映する。
  5. ビギナー人数を0に変更する。
  6. イベントを作成する。
  7. イベントに対応するワークショップ準備用issueを作成する。

--------------------

```